### PR TITLE
Add continuous integration via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ cache:
     directories:
         - '$HOME/.npm'
 
-before_script:
-    - npm run lint
-
 script: npm run build
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ branches:
     only:
         - master
 
-# See npm ci documentation
+# See npm ci documentation.
 install: npm ci
 cache:
     directories:
         - '$HOME/.npm'
 
-script: npm run build
+# Set CI to false so that warnings are not treated as errors.
+script: CI=false npm run build
 
 deploy:
     provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: node_js
+node_js:
+    - 10
+
+git:
+    depth: 1
+branches:
+    only:
+        - master
+
+# See npm ci documentation
+install: npm ci
+cache:
+    directories:
+        - '$HOME/.npm'
+
+before_script:
+    - npm run lint
+
+script: npm run build
+
+deploy:
+    provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    keep_history: true
+    on:
+        branch: master
+    local_dir: build
+    repo: acm-uci/acm-uci.github.io
+    target_branch: master


### PR DESCRIPTION
## Description

Add a Travis CI config to allow continuous deployment of the website. https://travis-ci.com/ACM-UCI/ACM-UCI-Website/ should show the current build state of the site. After this PR is merged, Travis will automatically build and deploy the website whenever you add commits to the `master` branch. On PR's like this one, Travis simply builds but does not deploy.

## TODOs

- [x] Fixes #59 
- [x] CI/CD

## Questions

## Status

- [x] Ready to go